### PR TITLE
fixes slider to only change playhead on mousup

### DIFF
--- a/admin/app/views/main.html
+++ b/admin/app/views/main.html
@@ -144,8 +144,8 @@
 
             <div class="mainControllers">
 
-                <div class="current">{{player.currentTime | _time}}</div>
-                <div class="remaining">{{(player.getDuration()-player.currentTime) | _time}}</div>
+                <div class="current">{{player.currentTimeVisual | _time}}</div>
+                <div class="remaining">{{(player.getDuration()-player.currentTimeVisual) | _time}}</div>
 
                 <div class="centered">
                     <div class="shuffle"

--- a/client/app/views/main.html
+++ b/client/app/views/main.html
@@ -198,8 +198,8 @@
 
             <div class="mainControllers">
 
-                <div class="current"><span ng-bind="player.currentTime | _time"></span></div>
-                <div class="remaining"><span ng-bind="(player.getDuration()-player.currentTime) | _time"></span></div>
+                <div class="current"><span ng-bind="player.currentTimeVisual | _time"></span></div>
+                <div class="remaining"><span ng-bind="(player.getDuration()-player.currentTimeVisual) | _time"></span></div>
 
                 <div class="centered">
                     <div class="shuffle"
@@ -223,8 +223,8 @@
 
                 </div>
 
-                <!--div class="current"><span ng-bind="player.currentTime | _time"></span></div>
-                <div class="remaining"><span ng-bind="(player.getDuration()-player.currentTime) | _time"></span></div-->
+                <!--div class="current"><span ng-bind="player.currentTimeVisual | _time"></span></div>
+                <div class="remaining"><span ng-bind="(player.getDuration()-player.currentTimeVisual) | _time"></span></div-->
                 <div class="slider"><div class="target"></div></div>
 
             </div>

--- a/common/app/scripts/directives/player.js
+++ b/common/app/scripts/directives/player.js
@@ -22,8 +22,8 @@ angular.module('bmmLibApp')
             '<div class="play" title="{{init.translation.notify.play}}" ng-class="{\'pause\': player.playing}" ng-click="player.togglePlay();"></div>' +
             '<div class="next" title="{{init.translation.notify.next}}" ng-click="player.setNext();"></div>' +
             '<div class="duration">' +
-              '{{player.currentTime | _time}} / ' +
-              '{{(player.getDuration()-player.currentTime) | _time}}' +
+              '{{player.currentTimeVisual | _time}} / ' +
+              '{{(player.getDuration()-player.currentTimeVisual) | _time}}' +
             '</div>' +
             '<div class="fullscreen-toggle" title="{{init.translation.notify.closeFullscreen}}"></div>' +
             '<div class="mute" title="{{init.translation.notify.mute}}" ng-hide="init.isIOS" ng-class="{\'active\': player.muted}" ng-click="player.setMute();"></div>' +
@@ -41,10 +41,16 @@ angular.module('bmmLibApp')
           },
           slide: function(e, ui) {
             trackSlider.find('.behind').css({ width: (100-ui.value)+'%' });
-            scope.player.setCurrentTime(ui.value);
+            scope.player.setVisualTime(ui.value);
+            scope.player.setIsSliding(true);
           },
           change: function(e, ui) {
             trackSlider.find('.behind').css({ width: (100-ui.value)+'%' });
+            //if the event e has the property handleObj then it's done via UserInput like mouseup
+            if(e.handleObj != null){
+              scope.player.setCurrentTime(ui.value);
+              scope.player.setIsSliding(false);
+            }
           }
         });
 

--- a/common/app/scripts/services/_player.js
+++ b/common/app/scripts/services/_player.js
@@ -8,6 +8,8 @@ angular.module('bmmLibApp')
       source;
 
   factory.currentTime = 0;
+  factory.isSliding = false;
+  factory.currentTimeVisual = 0;
   factory.currentTimePercent = 0;
   factory.volume = .8;
   factory.muted = false;
@@ -57,6 +59,9 @@ angular.module('bmmLibApp')
               $(videoTarget).data('jPlayer').status.currentTime;
             factory.currentTimePercent =
               $(videoTarget).data('jPlayer').status.currentPercentAbsolute;
+            if(!factory.isSliding){
+              factory.currentTimeVisual = factory.currentTime;
+            }
           });
         },
         ended: function() {
@@ -354,6 +359,14 @@ angular.module('bmmLibApp')
   factory.setCurrentTime = function(value) {
     $(videoTarget).jPlayer('playHead', value);
   };
+
+  factory.setVisualTime = function(value) {
+    factory.currentTimeVisual = (value / 100) * this.getDuration();
+  }
+
+  factory.setIsSliding = function(value) {
+    factory.isSliding = value;
+  }
 
   factory.getDuration = function() {
     return $(videoTarget).data('jPlayer').status.duration;


### PR DESCRIPTION
**Problem**
When you slide the slider for the track position, the player is instantaniously set to the given position which is a pretty bad user experience.
**Solution**
I've changed the code so the `slide` event only updates the `currentVisualTime`. The player itself is only updated once the `change` event with an e.handleObj is fired (due to a mouse-up event)
**Known Issues**
I couldn't test it with videos because I couldn't find any.